### PR TITLE
Implement MonCommand

### DIFF
--- a/rados/conn.go
+++ b/rados/conn.go
@@ -261,11 +261,10 @@ func (c *Conn) DeletePool(name string) error {
 }
 
 // MonCommand sends a command to one of the monitors
-func (c *Conn) MonCommand(args []string) (buffer, info string, err error) {
-	argv := make([]*C.char, len(commands))
-	for i, arg := range args {
-		argv[i] = C.CString(arg)
-		defer C.free(unsafe.Pointer(argv[i]))
+func (c *Conn) MonCommand(args []byte) (buffer, info string, err error) {
+	argv := make([]*C.char, len(args))
+	for i, _ := range args {
+		argv[i] = (*C.char)(unsafe.Pointer(&args[i]))
 	}
 
 	var (
@@ -276,7 +275,7 @@ func (c *Conn) MonCommand(args []string) (buffer, info string, err error) {
 	defer C.free(unsafe.Pointer(inbuf))
 
 	ret := C.rados_mon_command(c.cluster,
-		&argv[0], C.size_t(len(commands)),
+		&argv[0], C.size_t(len(args)),
 		inbuf,       // inbuf
 		C.size_t(0), // length inbuf
 		&outbuf,     // actual data

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -12,6 +12,7 @@ import "time"
 import "net"
 import "fmt"
 import "sort"
+import "encoding/json"
 
 func GetUUID() string {
     out, _ := exec.Command("uuidgen").Output()
@@ -373,6 +374,23 @@ func TestGetPoolName(t *testing.T) {
 
     ioctx.Destroy()
     conn.Shutdown()
+}
+
+func TestMonCommand(t *testing.T) {
+	conn, _ := rados.NewConn()
+    conn.ReadDefaultConfigFile()
+    conn.Connect()
+
+	command, err := json.Marshal(map[string]string{"prefix": "df", "format": "json"})
+	buf, info, err := conn.MonCommand(command)
+	assert.NoError(t, err)
+
+    var message map[string]interface{}
+	err = json.Unmarshal([]byte(buf), &message)
+	assert.NoError(t, err)
+
+	fmt.Println("Use ", info)
+	os.Stdout.Write([]byte(buf))
 }
 
 func TestObjectIterator(t *testing.T) {

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -382,15 +382,15 @@ func TestMonCommand(t *testing.T) {
     conn.Connect()
 
 	command, err := json.Marshal(map[string]string{"prefix": "df", "format": "json"})
+	assert.NoError(t, err)
+
 	buf, info, err := conn.MonCommand(command)
 	assert.NoError(t, err)
+	assert.Equal(t, info, "")
 
     var message map[string]interface{}
-	err = json.Unmarshal([]byte(buf), &message)
+	err = json.Unmarshal(buf, &message)
 	assert.NoError(t, err)
-
-	fmt.Println("Use ", info)
-	os.Stdout.Write([]byte(buf))
 }
 
 func TestObjectIterator(t *testing.T) {

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -391,6 +391,8 @@ func TestMonCommand(t *testing.T) {
     var message map[string]interface{}
 	err = json.Unmarshal(buf, &message)
 	assert.NoError(t, err)
+
+    conn.Shutdown()
 }
 
 func TestObjectIterator(t *testing.T) {


### PR DESCRIPTION
This version copies the data from the Carray to a []byte so one can start parsing using encoding.json straight away.

I've added a basic test that it gives results which parse using json's Unmarshall.

The implementation is not 100% compliant with librados' version, it doesn't support giving an 'inbuf'.