### PR TITLE
Added NewConnWithUser to allow users other than the default

### DIFF
--- a/rados/rados.go
+++ b/rados/rados.go
@@ -7,6 +7,7 @@ import "C"
 
 import (
 	"fmt"
+	"unsafe"
 )
 
 type RadosError int
@@ -28,6 +29,22 @@ func Version() (int, int, int) {
 func NewConn() (*Conn, error) {
 	conn := &Conn{}
 	ret := C.rados_create(&conn.cluster, nil)
+
+	if ret == 0 {
+		return conn, nil
+	} else {
+		return nil, RadosError(int(ret))
+	}
+}
+
+// NewConnWithUser creates a new connection object with a custom username.
+// It returns the connection and an error, if any.
+func NewConnWithUser(user string) (*Conn, error) {
+	c_user := C.CString(user)
+	defer C.free(unsafe.Pointer(c_user))
+
+	conn := &Conn{}
+	ret := C.rados_create(&conn.cluster, c_user)
 
 	if ret == 0 {
 		return conn, nil

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -436,3 +436,8 @@ func TestObjectIterator(t *testing.T) {
 
 	assert.Equal(t, objectList, createdList)
 }
+
+func TestNewConnWithUser(t *testing.T) {
+	_, err := rados.NewConnWithUser("admin")
+	assert.Equal(t, err, nil)
+}


### PR DESCRIPTION
We have a need to use usernames that are not the default `client.admin`.  This new `NewConnWithUser` is the same as `NewConn` except it adds the ability to pass in a username, without the `client.` prefix.

The user of this new function doesn't store their keyring at `/etc/ceph/ceph.client.$USER.keyring`, they would find value in setting their `keyring` (or `key` or `keyfile`) in their ceph config file or setting `conn.SetConfigOption("keyring", "/path/to/my/keyring")` (or the `key` or `keyfile` equivalent).