### PR TITLE
Add an overload for creating a connection to a non-default cluster name

### DIFF
--- a/rados/rados.go
+++ b/rados/rados.go
@@ -52,3 +52,21 @@ func NewConnWithUser(user string) (*Conn, error) {
 		return nil, RadosError(int(ret))
 	}
 }
+
+// NewConnWithClusterAndUser creates a new connection object for a specific cluster and username. 
+// It returns the connection and an error, if any.
+func NewConnWithClusterAndUser(clusterName string, userName string) (*Conn, error) {
+	c_cluster_name := C.CString(clusterName)
+	defer C.free(unsafe.Pointer(c_cluster_name))
+
+	c_name := C.CString(userName)
+	defer C.free(unsafe.Pointer(c_name))
+
+	conn := &Conn{}
+	ret := C.rados_create2(&conn.cluster, c_cluster_name, c_name, 0)
+	if ret == 0 {
+		return conn, nil
+	} else {
+		return nil, RadosError(int(ret))
+	}
+}

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -467,7 +467,7 @@ func TestNewConnWithUser(t *testing.T) {
 }
 
 func TestNewConnWithClusterAndUser(t *testing.T) {
-	_, err := rados.NewConnWithClusterAndUser("ceph", "admin")
+	_, err := rados.NewConnWithClusterAndUser("ceph", "client.admin")
 	assert.Equal(t, err, nil)
 }
 

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -466,6 +466,11 @@ func TestNewConnWithUser(t *testing.T) {
 	assert.Equal(t, err, nil)
 }
 
+func TestNewConnWithClusterAndUser(t *testing.T) {
+	_, err := rados.NewConnWithClusterAndUser("ceph", "admin")
+	assert.Equal(t, err, nil)
+}
+
 func TestReadWriteXattr(t *testing.T) {
 	conn, _ := rados.NewConn()
 	conn.ReadDefaultConfigFile()


### PR DESCRIPTION
This function will allow connecting to a cluster that does not have the default name of "ceph". This is necessary for our environment where we might have multiple ceph clusters running.