### PR TITLE
Convert some C error code to Go code

### DIFF
--- a/rados/ioctx.go
+++ b/rados/ioctx.go
@@ -62,11 +62,7 @@ func (ioctx *IOContext) Write(oid string, data []byte, offset uint64) error {
 		(C.size_t)(len(data)),
 		(C.uint64_t)(offset))
 
-	if ret == 0 {
-		return nil
-	} else {
-		return RadosError(int(ret))
-	}
+	return GetRadosError(ret)
 }
 
 // WriteFull writes len(data) bytes to the object with key oid.
@@ -79,12 +75,7 @@ func (ioctx *IOContext) WriteFull(oid string, data []byte) error {
 	ret := C.rados_write_full(ioctx.ioctx, c_oid,
 		(*C.char)(unsafe.Pointer(&data[0])),
 		(C.size_t)(len(data)))
-
-	if ret == 0 {
-		return nil
-	} else {
-		return RadosError(int(ret))
-	}
+	return GetRadosError(ret)
 }
 
 // Read reads up to len(data) bytes from the object with key oid starting at byte
@@ -107,10 +98,7 @@ func (ioctx *IOContext) Read(oid string, data []byte, offset uint64) (int, error
 	if ret >= 0 {
 		return int(ret), nil
 	} else {
-		if ret == -C.ENOENT {
-			return 0, RadosErrorNotFound
-		}
-		return 0, RadosError(int(ret))
+		return 0, GetRadosError(ret)
 	}
 }
 
@@ -119,13 +107,7 @@ func (ioctx *IOContext) Delete(oid string) error {
 	c_oid := C.CString(oid)
 	defer C.free(unsafe.Pointer(c_oid))
 
-	ret := C.rados_remove(ioctx.ioctx, c_oid)
-
-	if ret == 0 {
-		return nil
-	} else {
-		return RadosError(int(ret))
-	}
+	return GetRadosError(C.rados_remove(ioctx.ioctx, c_oid))
 }
 
 // Truncate resizes the object with key oid to size size. If the operation
@@ -136,13 +118,7 @@ func (ioctx *IOContext) Truncate(oid string, size uint64) error {
 	c_oid := C.CString(oid)
 	defer C.free(unsafe.Pointer(c_oid))
 
-	ret := C.rados_trunc(ioctx.ioctx, c_oid, (C.uint64_t)(size))
-
-	if ret == 0 {
-		return nil
-	} else {
-		return RadosError(int(ret))
-	}
+	return GetRadosError(C.rados_trunc(ioctx.ioctx, c_oid, (C.uint64_t)(size)))
 }
 
 // Destroy informs librados that the I/O context is no longer in use.
@@ -264,7 +240,7 @@ func (ioctx *IOContext) GetXattr(object string, name string, data []byte) (int, 
 	if ret >= 0 {
 		return int(ret), nil
 	} else {
-		return 0, RadosError(int(ret))
+		return 0, GetRadosError(ret)
 	}
 }
 
@@ -282,11 +258,7 @@ func (ioctx *IOContext) SetXattr(object string, name string, data []byte) error 
 		(*C.char)(unsafe.Pointer(&data[0])),
 		(C.size_t)(len(data)))
 
-	if ret == 0 {
-		return nil
-	} else {
-		return RadosError(int(ret))
-	}
+	return GetRadosError(ret)
 }
 
 // function that lists all the xattrs for an object, since xattrs are
@@ -300,7 +272,7 @@ func (ioctx *IOContext) ListXattrs(oid string) (map[string][]byte, error) {
 
 	ret := C.rados_getxattrs(ioctx.ioctx, c_oid, &it)
 	if ret < 0 {
-		return nil, RadosError(ret)
+		return nil, GetRadosError(ret)
 	}
 	defer func() { C.rados_getxattrs_end(it) }()
 	m := make(map[string][]byte)
@@ -312,7 +284,7 @@ func (ioctx *IOContext) ListXattrs(oid string) (map[string][]byte, error) {
 
 		ret := C.rados_getxattrs_next(it, &c_name, &c_val, &c_len)
 		if ret < 0 {
-			return nil, RadosError(int(ret))
+			return nil, GetRadosError(ret)
 		}
 		// rados api returns a null name,val & 0-length upon
 		// end of iteration
@@ -335,11 +307,7 @@ func (ioctx *IOContext) RmXattr(oid string, name string) error {
 		c_oid,
 		c_name)
 
-	if ret == 0 {
-		return nil
-	} else {
-		return RadosError(int(ret))
-	}
+	return GetRadosError(ret)
 }
 
 // Append the map `pairs` to the omap `oid`
@@ -395,11 +363,7 @@ func (ioctx *IOContext) SetOmap(oid string, pairs map[string][]byte) error {
 	ret := C.rados_write_op_operate(op, ioctx.ioctx, c_oid, nil, 0)
 	C.rados_release_write_op(op)
 
-	if ret == 0 {
-		return nil
-	} else {
-		return RadosError(int(ret))
-	}
+	return GetRadosError(ret)
 }
 
 // OmapListFunc is the type of the function called for each omap key
@@ -439,7 +403,7 @@ func (ioctx *IOContext) ListOmapValues(oid string, startAfter string, filterPref
 	if int(c_prval) != 0 {
 		return RadosError(int(c_prval))
 	} else if int(ret) != 0 {
-		return RadosError(int(ret))
+		return GetRadosError(ret)
 	}
 
 	for {
@@ -450,7 +414,7 @@ func (ioctx *IOContext) ListOmapValues(oid string, startAfter string, filterPref
 		ret = C.rados_omap_get_next(c_iter, &c_key, &c_val, &c_len)
 
 		if int(ret) != 0 {
-			return RadosError(int(ret))
+			return GetRadosError(ret)
 		}
 
 		if c_key == nil {
@@ -543,11 +507,7 @@ func (ioctx *IOContext) RmOmapKeys(oid string, keys []string) error {
 	ret := C.rados_write_op_operate(op, ioctx.ioctx, c_oid, nil, 0)
 	C.rados_release_write_op(op)
 
-	if ret == 0 {
-		return nil
-	} else {
-		return RadosError(int(ret))
-	}
+	return GetRadosError(ret)
 }
 
 // Clear the omap `oid`
@@ -561,9 +521,5 @@ func (ioctx *IOContext) CleanOmap(oid string) error {
 	ret := C.rados_write_op_operate(op, ioctx.ioctx, c_oid, nil, 0)
 	C.rados_release_write_op(op)
 
-	if ret == 0 {
-		return nil
-	} else {
-		return RadosError(int(ret))
-	}
+	return GetRadosError(ret)
 }

--- a/rados/ioctx.go
+++ b/rados/ioctx.go
@@ -1,6 +1,7 @@
 package rados
 
 // #cgo LDFLAGS: -lrados
+// #include <errno.h>
 // #include <stdlib.h>
 // #include <rados/librados.h>
 import "C"
@@ -106,6 +107,9 @@ func (ioctx *IOContext) Read(oid string, data []byte, offset uint64) (int, error
 	if ret >= 0 {
 		return int(ret), nil
 	} else {
+		if ret == -C.ENOENT {
+			return 0, RadosErrorNotFound
+		}
 		return 0, RadosError(int(ret))
 	}
 }

--- a/rados/rados.go
+++ b/rados/rados.go
@@ -1,6 +1,7 @@
 package rados
 
 // #cgo LDFLAGS: -lrados
+// #include <errno.h>
 // #include <stdlib.h>
 // #include <rados/librados.h>
 import "C"
@@ -18,6 +19,17 @@ func (e RadosError) Error() string {
 }
 
 var RadosErrorNotFound = errors.New("Rados error not found")
+
+func GetRadosError(err C.int) error {
+	if err != 0 {
+		if err == -C.ENOENT {
+			return RadosErrorNotFound
+		}
+		return RadosError(err)
+	} else {
+		return nil
+	}
+}
 
 // Version returns the major, minor, and patch components of the version of
 // the RADOS library linked against.

--- a/rados/rados.go
+++ b/rados/rados.go
@@ -6,6 +6,7 @@ package rados
 import "C"
 
 import (
+	"errors"
 	"fmt"
 	"unsafe"
 )
@@ -15,6 +16,8 @@ type RadosError int
 func (e RadosError) Error() string {
 	return fmt.Sprintf("rados: ret=%d", e)
 }
+
+var RadosErrorNotFound = errors.New("Rados error not found")
 
 // Version returns the major, minor, and patch components of the version of
 // the RADOS library linked against.

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -318,6 +318,32 @@ func TestReadWrite(t *testing.T) {
 	assert.Equal(t, bytes_in, bytes_out)
 
 	pool.Destroy()
+	conn.Shutdown()
+}
+
+func TestNotFound(t *testing.T) {
+	conn, _ := rados.NewConn()
+	conn.ReadDefaultConfigFile()
+	conn.Connect()
+
+	// make pool
+	pool_name := GetUUID()
+	err := conn.MakePool(pool_name)
+	assert.NoError(t, err)
+
+	pool, err := conn.OpenIOContext(pool_name)
+	assert.NoError(t, err)
+
+	size := 128
+	bytes_out := make([]byte, size)
+	_, err = pool.Read("obj", bytes_out, 0)
+	assert.Equal(t, err, rados.RadosErrorNotFound)
+
+	err = pool.Delete("obj")
+	assert.Equal(t, err, rados.RadosErrorNotFound)
+
+	pool.Destroy()
+	conn.Shutdown()
 }
 
 func TestObjectStat(t *testing.T) {

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -1,6 +1,7 @@
 package rbd
 
 // #cgo LDFLAGS: -lrbd
+// #include <errno.h>
 // #include <stdlib.h>
 // #include <rados/librados.h>
 // #include <rbd/librbd.h>
@@ -18,7 +19,12 @@ import (
 //
 type RBDError int
 
-var ImageNotOpen = errors.New("RBD image not open")
+var RbdErrorImageNotOpen = errors.New("RBD image not open")
+var RbdErrorNotFound = errors.New("RBD image not found")
+
+//Rdb feature
+var RbdFeatureLayering = uint64(1 << 0)
+var RbdFeatureStripingV2 = uint64(1 << 1)
 
 //
 type ImageInfo struct {
@@ -84,6 +90,9 @@ func (e RBDError) Error() string {
 //
 func GetError(err C.int) error {
 	if err != 0 {
+		if err == -C.ENOENT {
+			return RbdErrorNotFound
+		}
 		return RBDError(err)
 	} else {
 		return nil
@@ -259,6 +268,9 @@ func (image *Image) Open(args ...interface{}) error {
 	image.image = c_image
 
 	if ret != 0 {
+		if ret == -C.ENOENT {
+			return RbdErrorNotFound
+		}
 		return RBDError(ret)
 	}
 	return nil
@@ -267,7 +279,7 @@ func (image *Image) Open(args ...interface{}) error {
 // int rbd_close(rbd_image_t image);
 func (image *Image) Close() error {
 	if image.image == nil {
-		return ImageNotOpen
+		return RbdErrorImageNotOpen
 	}
 
 	ret := C.rbd_close(image.image)
@@ -281,7 +293,7 @@ func (image *Image) Close() error {
 // int rbd_resize(rbd_image_t image, uint64_t size);
 func (image *Image) Resize(size uint64) error {
 	if image.image == nil {
-		return ImageNotOpen
+		return RbdErrorImageNotOpen
 	}
 
 	return GetError(C.rbd_resize(image.image, C.uint64_t(size)))
@@ -290,7 +302,7 @@ func (image *Image) Resize(size uint64) error {
 // int rbd_stat(rbd_image_t image, rbd_image_info_t *info, size_t infosize);
 func (image *Image) Stat() (info *ImageInfo, err error) {
 	if image.image == nil {
-		return nil, ImageNotOpen
+		return nil, RbdErrorImageNotOpen
 	}
 
 	var c_stat C.rbd_image_info_t
@@ -313,7 +325,7 @@ func (image *Image) Stat() (info *ImageInfo, err error) {
 // int rbd_get_old_format(rbd_image_t image, uint8_t *old);
 func (image *Image) IsOldFormat() (old_format bool, err error) {
 	if image.image == nil {
-		return false, ImageNotOpen
+		return false, RbdErrorImageNotOpen
 	}
 
 	var c_old_format C.uint8_t
@@ -329,7 +341,7 @@ func (image *Image) IsOldFormat() (old_format bool, err error) {
 // int rbd_size(rbd_image_t image, uint64_t *size);
 func (image *Image) GetSize() (size uint64, err error) {
 	if image.image == nil {
-		return 0, ImageNotOpen
+		return 0, RbdErrorImageNotOpen
 	}
 
 	ret := C.rbd_get_size(image.image,
@@ -344,7 +356,7 @@ func (image *Image) GetSize() (size uint64, err error) {
 // int rbd_get_features(rbd_image_t image, uint64_t *features);
 func (image *Image) GetFeatures() (features uint64, err error) {
 	if image.image == nil {
-		return 0, ImageNotOpen
+		return 0, RbdErrorImageNotOpen
 	}
 
 	ret := C.rbd_get_features(image.image,
@@ -359,7 +371,7 @@ func (image *Image) GetFeatures() (features uint64, err error) {
 // int rbd_get_stripe_unit(rbd_image_t image, uint64_t *stripe_unit);
 func (image *Image) GetStripeUnit() (stripe_unit uint64, err error) {
 	if image.image == nil {
-		return 0, ImageNotOpen
+		return 0, RbdErrorImageNotOpen
 	}
 
 	ret := C.rbd_get_stripe_unit(image.image, (*C.uint64_t)(&stripe_unit))
@@ -373,7 +385,7 @@ func (image *Image) GetStripeUnit() (stripe_unit uint64, err error) {
 // int rbd_get_stripe_count(rbd_image_t image, uint64_t *stripe_count);
 func (image *Image) GetStripeCount() (stripe_count uint64, err error) {
 	if image.image == nil {
-		return 0, ImageNotOpen
+		return 0, RbdErrorImageNotOpen
 	}
 
 	ret := C.rbd_get_stripe_count(image.image, (*C.uint64_t)(&stripe_count))
@@ -387,7 +399,7 @@ func (image *Image) GetStripeCount() (stripe_count uint64, err error) {
 // int rbd_get_overlap(rbd_image_t image, uint64_t *overlap);
 func (image *Image) GetOverlap() (overlap uint64, err error) {
 	if image.image == nil {
-		return 0, ImageNotOpen
+		return 0, RbdErrorImageNotOpen
 	}
 
 	ret := C.rbd_get_overlap(image.image, (*C.uint64_t)(&overlap))
@@ -406,7 +418,7 @@ func (image *Image) GetOverlap() (overlap uint64, err error) {
 //                librbd_progress_fn_t cb, void *cbdata);
 func (image *Image) Copy(args ...interface{}) error {
 	if image.image == nil {
-		return ImageNotOpen
+		return RbdErrorImageNotOpen
 	}
 
 	switch t := args[0].(type) {
@@ -447,7 +459,7 @@ func (image *Image) Flatten() error {
 //               char *images, size_t *images_len);
 func (image *Image) ListChildren() (pools []string, images []string, err error) {
 	if image.image == nil {
-		return nil, nil, ImageNotOpen
+		return nil, nil, RbdErrorImageNotOpen
 	}
 
 	var c_pools_len, c_images_len C.size_t
@@ -497,7 +509,7 @@ func (image *Image) ListChildren() (pools []string, images []string, err error) 
 //              char *addrs, size_t *addrs_len);
 func (image *Image) ListLockers() (tag string, lockers []Locker, err error) {
 	if image.image == nil {
-		return "", nil, ImageNotOpen
+		return "", nil, RbdErrorImageNotOpen
 	}
 
 	var c_exclusive C.int
@@ -537,7 +549,7 @@ func (image *Image) ListLockers() (tag string, lockers []Locker, err error) {
 // int rbd_lock_exclusive(rbd_image_t image, const char *cookie);
 func (image *Image) LockExclusive(cookie string) error {
 	if image.image == nil {
-		return ImageNotOpen
+		return RbdErrorImageNotOpen
 	}
 
 	var c_cookie *C.char = C.CString(cookie)
@@ -549,7 +561,7 @@ func (image *Image) LockExclusive(cookie string) error {
 // int rbd_lock_shared(rbd_image_t image, const char *cookie, const char *tag);
 func (image *Image) LockShared(cookie string, tag string) error {
 	if image.image == nil {
-		return ImageNotOpen
+		return RbdErrorImageNotOpen
 	}
 
 	var c_cookie *C.char = C.CString(cookie)
@@ -563,7 +575,7 @@ func (image *Image) LockShared(cookie string, tag string) error {
 // int rbd_lock_shared(rbd_image_t image, const char *cookie, const char *tag);
 func (image *Image) Unlock(cookie string) error {
 	if image.image == nil {
-		return ImageNotOpen
+		return RbdErrorImageNotOpen
 	}
 
 	var c_cookie *C.char = C.CString(cookie)
@@ -575,7 +587,7 @@ func (image *Image) Unlock(cookie string) error {
 // int rbd_break_lock(rbd_image_t image, const char *client, const char *cookie);
 func (image *Image) BreakLock(client string, cookie string) error {
 	if image.image == nil {
-		return ImageNotOpen
+		return RbdErrorImageNotOpen
 	}
 
 	var c_client *C.char = C.CString(client)
@@ -597,7 +609,7 @@ func (image *Image) BreakLock(client string, cookie string) error {
 //              int (*cb)(uint64_t, size_t, int, void *), void *arg);
 func (image *Image) Read(data []byte) (n int, err error) {
 	if image.image == nil {
-		return 0, ImageNotOpen
+		return 0, RbdErrorImageNotOpen
 	}
 
 	if len(data) == 0 {
@@ -687,7 +699,7 @@ func (image *Image) Flush() error {
 // void rbd_snap_list_end(rbd_snap_info_t *snaps);
 func (image *Image) GetSnapshotNames() (snaps []SnapInfo, err error) {
 	if image.image == nil {
-		return nil, ImageNotOpen
+		return nil, RbdErrorImageNotOpen
 	}
 
 	var c_max_snaps C.int = 0
@@ -716,7 +728,7 @@ func (image *Image) GetSnapshotNames() (snaps []SnapInfo, err error) {
 // int rbd_snap_create(rbd_image_t image, const char *snapname);
 func (image *Image) CreateSnapshot(snapname string) (*Snapshot, error) {
 	if image.image == nil {
-		return nil, ImageNotOpen
+		return nil, RbdErrorImageNotOpen
 	}
 
 	var c_snapname *C.char = C.CString(snapname)

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -267,13 +267,7 @@ func (image *Image) Open(args ...interface{}) error {
 
 	image.image = c_image
 
-	if ret != 0 {
-		if ret == -C.ENOENT {
-			return RbdErrorNotFound
-		}
-		return RBDError(ret)
-	}
-	return nil
+	return GetError(ret)
 }
 
 // int rbd_close(rbd_image_t image);

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -230,3 +230,29 @@ func TestParentInfo(t *testing.T) {
 	conn.DeletePool(poolname)
 	conn.Shutdown()
 }
+
+func TestNotFound(t *testing.T) {
+	conn, _ := rados.NewConn()
+	conn.ReadDefaultConfigFile()
+	conn.Connect()
+
+	poolname := GetUUID()
+	err := conn.MakePool(poolname)
+	assert.NoError(t, err)
+
+	ioctx, err := conn.OpenIOContext(poolname)
+	assert.NoError(t, err)
+
+	name := GetUUID()
+
+	img := rbd.GetImage(ioctx, name)
+	err = img.Open()
+	assert.Equal(t, err, rbd.RbdErrorNotFound)
+
+	img.Remove()
+	assert.Equal(t, err, rbd.RbdErrorNotFound)
+
+	ioctx.Destroy()
+	conn.DeletePool(poolname)
+	conn.Shutdown()
+}


### PR DESCRIPTION
Convert some C error code to Go code, for convenient Golang code to handle error.
Define some Rbd constant variables, to pass to librbd API.

Signed-off-by: Ye Yin eyniy@qq.com
